### PR TITLE
Stackable Recipes

### DIFF
--- a/src/main/java/online/kingdomkeys/kingdomkeys/item/ModItems.java
+++ b/src/main/java/online/kingdomkeys/kingdomkeys/item/ModItems.java
@@ -760,7 +760,7 @@ public class ModItems {
 			finalOrb = createNewItem(Strings.LevelUpFinal, () -> new UpgradeDriveFormItem(new Item.Properties().group(KingdomKeys.miscGroup), KingdomKeys.MODID+":form_final")),
 			
 			synthesisBag = createNewItem("synthesis_bag", () -> new SynthesisBagItem(new Item.Properties().group(KingdomKeys.miscGroup).maxStackSize(1))),
-    		recipe = createNewItem("recipe", () -> new RecipeItem(new Item.Properties().group(KingdomKeys.miscGroup).maxStackSize(1))),
+    		recipe = createNewItem("recipe", () -> new RecipeItem(new Item.Properties().group(KingdomKeys.miscGroup).maxStackSize(16))),
 
 			proofOfHeart = createNewItem("proof_of_heart", () -> new ProofOfHeartItem(new Item.Properties().group(KingdomKeys.miscGroup))),
 			

--- a/src/main/java/online/kingdomkeys/kingdomkeys/item/RecipeItem.java
+++ b/src/main/java/online/kingdomkeys/kingdomkeys/item/RecipeItem.java
@@ -38,38 +38,13 @@ public class RecipeItem extends Item implements IItemCategory {
 		if (hand == Hand.MAIN_HAND) {
 			if (!world.isRemote) {
 				ItemStack stack = player.getHeldItemMainhand();
+
+				//Allow recipes to be given with pre-set keyblades
+				//If a recipe already has a tag, it will try learn those
+				//If the player already has learnt them, the recipe item will be refreshed to try get new recipes.
 				if (stack.hasTag()) {
-					String[] recipes = { stack.getTag().getString("recipe1"), stack.getTag().getString("recipe2"), stack.getTag().getString("recipe3") };
-					IPlayerCapabilities playerData = ModCapabilities.getPlayer(player);
-					// /give Abelatox kingdomkeys:recipe{recipe1:"kingdomkeys:oathkeeper",recipe2:"kingdomkeys:diamond"} 1
-
-					boolean consume = false;
-					for (String recipe : recipes) {
-						ResourceLocation rl = new ResourceLocation(recipe);
-						if (RecipeRegistry.getInstance().containsKey(rl)) {
-							ItemStack outputStack = new ItemStack(RecipeRegistry.getInstance().getValue(rl).getResult());							
-							if (recipe == null || !RecipeRegistry.getInstance().containsKey(rl)) { // If recipe is not valid
-								String message = "ERROR: Recipe for " + Utils.translateToLocal(rl.toString()) + " was not learnt because it is not a valid recipe, Report this to a dev";
-								player.sendMessage(new TranslationTextComponent(TextFormatting.RED + message), Util.DUMMY_UUID);
-							} else if (playerData.hasKnownRecipe(rl)) { // If recipe already known
-								String message = "Recipe for " + Utils.translateToLocal(outputStack.getTranslationKey()) + " already learnt";
-								player.sendMessage(new TranslationTextComponent(TextFormatting.YELLOW + message), Util.DUMMY_UUID);
-							} else { // If recipe is not known, learn it
-								playerData.addKnownRecipe(rl);
-								consume = true;
-								String message = "Recipe " + Utils.translateToLocal(outputStack.getTranslationKey()) + " learnt successfully";
-								player.sendMessage(new TranslationTextComponent(TextFormatting.GREEN + message), Util.DUMMY_UUID);
-								PacketHandler.sendTo(new SCSyncCapabilityPacket(playerData), (ServerPlayerEntity) player);
-							}
-						}
-					}
-
-					if (consume) {
-						player.getHeldItemMainhand().shrink(1);
-					} else {
-						shuffleRecipes(stack, player, stack.getTag().getString("type"));
-					}
-				} else {					
+					learnRecipes(player, stack);
+				} else {
 					IPlayerCapabilities playerData = ModCapabilities.getPlayer(player);
 					List<ResourceLocation> missingKeyblades = getMissingRecipes(playerData, "keyblade");
 					List<ResourceLocation> missingItems = getMissingRecipes(playerData, "item");
@@ -97,12 +72,56 @@ public class RecipeItem extends Item implements IItemCategory {
 					
 					player.sendStatusMessage(new TranslationTextComponent("Opened "+type+" recipe"), true);
 
-					
-					shuffleRecipes(stack, (PlayerEntity) player, type);
+					//Set up the recipe item with the given type
+					//We get here if there are recipes still available to learn.
+					shuffleRecipes(stack, player, type);
 				}
 			}
 		}
 		return super.onItemRightClick(world, player, hand);
+	}
+
+	private void learnRecipes(PlayerEntity player, ItemStack stack)
+	{
+		String[] recipes = { stack.getTag().getString("recipe1"), stack.getTag().getString("recipe2"), stack.getTag().getString("recipe3") };
+		IPlayerCapabilities playerData = ModCapabilities.getPlayer(player);
+		// /give Abelatox kingdomkeys:recipe{recipe1:"kingdomkeys:oathkeeper",recipe2:"kingdomkeys:diamond"} 1
+
+		boolean consume = false;
+		for (String recipe : recipes) {
+			ResourceLocation rl = new ResourceLocation(recipe);
+			if (RecipeRegistry.getInstance().containsKey(rl)) {
+				ItemStack outputStack = new ItemStack(RecipeRegistry.getInstance().getValue(rl).getResult());
+				if (recipe == null || !RecipeRegistry.getInstance().containsKey(rl)) { // If recipe is not valid
+					String message = "ERROR: Recipe for " + Utils.translateToLocal(rl.toString()) + " was not learnt because it is not a valid recipe, Report this to a dev";
+					player.sendMessage(new TranslationTextComponent(TextFormatting.RED + message), Util.DUMMY_UUID);
+				} else if (playerData.hasKnownRecipe(rl)) { // If recipe already known
+					String message = "Recipe for " + Utils.translateToLocal(outputStack.getTranslationKey()) + " already learnt";
+					player.sendMessage(new TranslationTextComponent(TextFormatting.YELLOW + message), Util.DUMMY_UUID);
+				} else { // If recipe is not known, learn it
+					playerData.addKnownRecipe(rl);
+					consume = true;
+					String message = "Recipe " + Utils.translateToLocal(outputStack.getTranslationKey()) + " learnt successfully";
+					player.sendMessage(new TranslationTextComponent(TextFormatting.GREEN + message), Util.DUMMY_UUID);
+					PacketHandler.sendTo(new SCSyncCapabilityPacket(playerData), (ServerPlayerEntity) player);
+				}
+			}
+		}
+
+		if (consume) {
+			//remove all child tags so we don't contaminate the stack
+			//This will set the stack's tag field to null once all are removed.
+			stack.removeChildTag("recipe1");
+			stack.removeChildTag("recipe2");
+			stack.removeChildTag("recipe3");
+			stack.removeChildTag("type");
+			//reduce stack size by one.
+			player.getHeldItemMainhand().shrink(1);
+		} else {
+			//try for fresh recipes, based on what type this stack was set to. No swapping from keyblade to item recipes etc.
+			//will fail successfully if none left.
+			shuffleRecipes(stack, player, stack.getTag().getString("type"));
+		}
 	}
 
 	public void shuffleRecipes(ItemStack stack, PlayerEntity player, String type) {
@@ -143,15 +162,24 @@ public class RecipeItem extends Item implements IItemCategory {
 			}
 			break;
 		}
-		
-		stack.setTag(new CompoundNBT());
-		stack.getTag().putString("type", type);
+
+		stack.getOrCreateTag().putString("type", type);
+
+		//if any recipes are on this stack, such as already learned ones, they should get overwritten
 		if(recipe1 != null)
-			stack.getTag().putString("recipe1", recipe1.toString());
+			stack.getOrCreateTag().putString("recipe1", recipe1.toString());
 		if(recipe2 != null)
-			stack.getTag().putString("recipe2", recipe2.toString());
+			stack.getOrCreateTag().putString("recipe2", recipe2.toString());
 		if(recipe3 != null)
-			stack.getTag().putString("recipe3", recipe3.toString());
+			stack.getOrCreateTag().putString("recipe3", recipe3.toString());
+
+		//Call learn recipes immediately.
+		//This will remove all child tags and then reduce stack size by one
+		//recipe1 is not null if any recipes exist to learn
+		if (recipe1 != null)
+		{
+			learnRecipes(player, stack);
+		}
 	}
 
 	private List<ResourceLocation> getMissingRecipes(IPlayerCapabilities playerData, String type) {

--- a/src/main/java/online/kingdomkeys/kingdomkeys/item/RecipeItem.java
+++ b/src/main/java/online/kingdomkeys/kingdomkeys/item/RecipeItem.java
@@ -83,9 +83,10 @@ public class RecipeItem extends Item implements IItemCategory {
 
 	private void learnRecipes(PlayerEntity player, ItemStack stack)
 	{
-		String[] recipes = { stack.getTag().getString("recipe1"), stack.getTag().getString("recipe2"), stack.getTag().getString("recipe3") };
+		final CompoundNBT stackTag = stack.getTag();
+		String[] recipes = { stackTag.getString("recipe1"), stackTag.getString("recipe2"), stackTag.getString("recipe3") };
 		IPlayerCapabilities playerData = ModCapabilities.getPlayer(player);
-		// /give Abelatox kingdomkeys:recipe{recipe1:"kingdomkeys:oathkeeper",recipe2:"kingdomkeys:diamond"} 1
+		// /give Dev kingdomkeys:recipe{type:"keyblade",recipe1:"kingdomkeys:oathkeeper",recipe2:"kingdomkeys:fenrir"} 16
 
 		boolean consume = false;
 		for (String recipe : recipes) {
@@ -120,7 +121,7 @@ public class RecipeItem extends Item implements IItemCategory {
 		} else {
 			//try for fresh recipes, based on what type this stack was set to. No swapping from keyblade to item recipes etc.
 			//will fail successfully if none left.
-			shuffleRecipes(stack, player, stack.getTag().getString("type"));
+			shuffleRecipes(stack, player, stackTag.getString("type"));
 		}
 	}
 


### PR DESCRIPTION
Recipe changes:
- Item stacks to 16. 
- Recipes are learnt automatically on right click (if any are available), no more right clicking to set the recipes, then right clicking again to learn them.
- ItemStack can have pre-set recipes set and will be learned as normal. If user already knows all the recipes set, new recipes will be shuffled based on type.