### PR TITLE
Guess who forgot to register the loot modifiers deferred register.

### DIFF
--- a/src/main/java/online/kingdomkeys/kingdomkeys/KingdomKeys.java
+++ b/src/main/java/online/kingdomkeys/kingdomkeys/KingdomKeys.java
@@ -59,6 +59,7 @@ import online.kingdomkeys.kingdomkeys.item.ModItems;
 import online.kingdomkeys.kingdomkeys.item.organization.OrganizationDataLoader;
 import online.kingdomkeys.kingdomkeys.leveling.LevelingDataLoader;
 import online.kingdomkeys.kingdomkeys.lib.Strings;
+import online.kingdomkeys.kingdomkeys.loot.ModLootModifier;
 import online.kingdomkeys.kingdomkeys.magic.MagicDataLoader;
 import online.kingdomkeys.kingdomkeys.network.PacketHandler;
 import online.kingdomkeys.kingdomkeys.proxy.IProxy;
@@ -114,6 +115,7 @@ public class KingdomKeys {
 		ModSounds.SOUNDS.register(modEventBus);
 		ModEntities.TILE_ENTITIES.register(modEventBus);
         ModContainers.CONTAINERS.register(modEventBus);
+        ModLootModifier.LOOT_MODIFIERS.register(modEventBus);
 
         ModEntities.ENTITIES.register(modEventBus);
 

--- a/src/main/java/online/kingdomkeys/kingdomkeys/loot/FortuneBonusModifier.java
+++ b/src/main/java/online/kingdomkeys/kingdomkeys/loot/FortuneBonusModifier.java
@@ -88,7 +88,7 @@ public class FortuneBonusModifier extends LootModifier
     {
         public Serializer()
         {
-            KingdomKeys.LOGGER.info("Fortune bonus modifier setting up");
+            KingdomKeys.LOGGER.info("LuckyLucky Fortune bonus modifier registered.");
         }
 
         public FortuneBonusModifier read(ResourceLocation location, JsonObject object, ILootCondition[] conditions)


### PR DESCRIPTION
Apparently I didn't test block fortune properly, but this change prevents the logs from complaining and can parse the loot modifier correctly now