### PR TITLE
Translatable Magical Chest Lore

### DIFF
--- a/src/main/java/online/kingdomkeys/kingdomkeys/block/MagicalChestBlock.java
+++ b/src/main/java/online/kingdomkeys/kingdomkeys/block/MagicalChestBlock.java
@@ -59,7 +59,7 @@ public class MagicalChestBlock extends BaseEntityBlock {
 	@OnlyIn(Dist.CLIENT)
 	@Override
 	public void appendHoverText(ItemStack stack, @Nullable BlockGetter worldIn, List<Component> tooltip, TooltipFlag flagIn) {
-		tooltip.add(Component.translatable("Can be locked with a keyblade"));
+		tooltip.add(Component.translatable("message.chest.can_be_locked"));
 		super.appendHoverText(stack, worldIn, tooltip, flagIn);
 	}
 


### PR DESCRIPTION
I dunno if this is right or would work, but it matches the rest ig

This line is left untranslated and thus remains in english across all languages, depsite having the same content as the `chest can be locked message`