### PR TITLE
Menu button fixes

### DIFF
--- a/src/main/java/online/kingdomkeys/kingdomkeys/client/gui/menu/customize/MenuCustomizeMagicScreen.java
+++ b/src/main/java/online/kingdomkeys/kingdomkeys/client/gui/menu/customize/MenuCustomizeMagicScreen.java
@@ -136,11 +136,13 @@ public class MenuCustomizeMagicScreen extends MenuBackground {
         boxRight = new MenuBox((int) boxRightPosX, (int) topBarHeight, (int) boxWidth, (int) middleHeight, new Color(4, 4, 68));
         buttonsX = boxLeft.getX() + 10;
 
+        buttonPosY = topBarHeight + 5;
+
         super.init();
         addRenderableWidget(rightScroll = new MenuScrollBar((int) (boxRightPosX + boxWidth - 14), (int) topBarHeight, 14, 1, (int) topBarHeight, (int) (topBarHeight + middleHeight)));
         addRenderableWidget(leftScroll = new MenuScrollBar((int) (boxLeftPosX + boxWidth - 14), (int) topBarHeight, 14, 1, (int) topBarHeight, (int) (topBarHeight + middleHeight)));
         updateMagicButtons(true);
-        addRenderableWidget(back = new MenuButton((int) buttonPosX, (int) topBarHeight + (0 * 18), (int) buttonWidth, Utils.translateToLocal(Strings.Gui_Menu_Back), MenuButton.ButtonType.BUTTON, (e) -> action("back")));
+        addRenderableWidget(back = new MenuButton((int) buttonPosX, (int) buttonPosY, (int) buttonWidth, Utils.translateToLocal(Strings.Gui_Menu_Back), MenuButton.ButtonType.BUTTON, (e) -> action("back")));
 
     }
 

--- a/src/main/java/online/kingdomkeys/kingdomkeys/client/gui/menu/items/equipment/MenuEquipmentScreen.java
+++ b/src/main/java/online/kingdomkeys/kingdomkeys/client/gui/menu/items/equipment/MenuEquipmentScreen.java
@@ -55,6 +55,7 @@ public class MenuEquipmentScreen extends MenuScrollScreen {
         buttonWidth = ((float)width * 0.07F);
         float listBoxX = width * 0.16F;
         float boxY = height * 0.174F;
+	float topBarHeight = height * 0.17F;
         float listBoxWidth = width * 0.452F;
         float boxHeight = height * 0.5972F;
         float detailsWidth = width * 0.2588F;
@@ -68,8 +69,8 @@ public class MenuEquipmentScreen extends MenuScrollScreen {
         
         float itemsX = width * 0.31F;
         float itemsY = height * 0.1907F;
-        buttonPosY = 48;
-        buttonPosX = 14.4F;
+        buttonPosY = topBarHeight+5;
+        buttonPosX = 15.4F;
         
         IPlayerCapabilities playerData = ModCapabilities.getPlayer(minecraft.player);
 


### PR DESCRIPTION
There were some button positions (mainly in the shortcuts/customize area and item equipment)

I tried to use a bit of "math" or something to make them start at the exact same position
**THIS DOES NEED TESTING THOUGH**

Some stuff could be right, but I dunno about most of them

And I also noticed that in most of these screens there is the `topBarHeight` re-defined(?) in the `init()` function, depsite their super class having the same value.
Would removing that re-definition result in the same number still?


(I would test the mod changes on my own, but my pc doesn't always do that well with modding and gets angry at me)

If this is all coded wrong, then you can also ignore/reject this pr

