### PR TITLE
Minor Translation Oversights + German Protect

### DIFF
--- a/src/main/java/online/kingdomkeys/kingdomkeys/client/gui/synthesis/ShopScreen.java
+++ b/src/main/java/online/kingdomkeys/kingdomkeys/client/gui/synthesis/ShopScreen.java
@@ -290,7 +290,7 @@ public class ShopScreen extends MenuFilterable {
 				String line = item.getCost()+" "+Utils.translateToLocal(Strings.Gui_Menu_Main_Munny);
 				gui.drawString(minecraft.font, line, boxM.getWidth() - minecraft.font.width(line) - 10, -20, item.getCost() > playerData.getMunny() ? Color.RED.getRGB() : Color.GREEN.getRGB());
 				gui.drawString(minecraft.font, Utils.translateToLocal(Strings.Gui_Shop_Tier)+" ", 2, -10, Color.yellow.getRGB());
-				line = Utils.getTierFromInt(item.getTier())+" "+(10 + item.getTier()*2)+" exp";
+				line = Utils.getTierFromInt(item.getTier())+" - "+(10 + item.getTier()*2)+" "+Utils.translateToLocal(Strings.Gui_Synthesis_Exp);
 				gui.drawString(minecraft.font, line, boxM.getWidth() - minecraft.font.width(line) - 10, -10, item.getTier() > playerData.getSynthLevel() ? Color.RED.getRGB() : Color.GREEN.getRGB());
 				
 				matrixStack.scale((float)(boxM.getWidth() / 16F - offset / 16F), (float)(boxM.getWidth() / 16F - offset / 16F), 1);

--- a/src/main/java/online/kingdomkeys/kingdomkeys/client/gui/synthesis/SynthesisCreateScreen.java
+++ b/src/main/java/online/kingdomkeys/kingdomkeys/client/gui/synthesis/SynthesisCreateScreen.java
@@ -268,7 +268,7 @@ public class SynthesisCreateScreen extends MenuFilterable {
 				String line = recipe.getCost()+" "+Utils.translateToLocal(Strings.Gui_Menu_Main_Munny);
 				gui.drawString(minecraft.font, line, boxM.getWidth() - minecraft.font.width(line) - 10, -20, recipe.getCost() > playerData.getMunny() ? Color.RED.getRGB() : Color.GREEN.getRGB());
 				gui.drawString(minecraft.font, Utils.translateToLocal(Strings.Gui_Shop_Tier)+" ", 2, -10, Color.yellow.getRGB());
-				line = Utils.getTierFromInt(recipe.getTier())+" "+(10 + recipe.getTier()*2)+" exp";
+				line = Utils.getTierFromInt(recipe.getTier())+" - "+(10 + recipe.getTier()*2)+" "+Utils.translateToLocal(Strings.Gui_Synthesis_Exp);
 				gui.drawString(minecraft.font, line, boxM.getWidth() - minecraft.font.width(line) - 10, -10, recipe.getTier() > playerData.getSynthLevel() ? Color.RED.getRGB() : Color.GREEN.getRGB());
 			}
 			float size = 80;

--- a/src/main/java/online/kingdomkeys/kingdomkeys/client/gui/synthesis/SynthesisForgeScreen.java
+++ b/src/main/java/online/kingdomkeys/kingdomkeys/client/gui/synthesis/SynthesisForgeScreen.java
@@ -252,7 +252,7 @@ public class SynthesisForgeScreen extends MenuFilterable {
 		{
 			matrixStack.translate(width * 0.03F + 45, (height * 0.15) - 18, 1);
 			RenderSystem.setShaderColor(1, 1, 1, 1);
-			gui.drawString(minecraft.font, Utils.translateToLocal("Page: " + (page + 1)), 0, 10, 0xFF9900);
+			gui.drawString(minecraft.font, Utils.translateToLocal(Strings.Gui_Shop_Page) + " " + (page + 1), 0, 10, 0xFF9900);
 			
 		}
 		matrixStack.popPose();

--- a/src/main/java/online/kingdomkeys/kingdomkeys/datagen/init/LanguageENUS.java
+++ b/src/main/java/online/kingdomkeys/kingdomkeys/datagen/init/LanguageENUS.java
@@ -181,6 +181,7 @@ public class LanguageENUS extends KKLanguageProvider {
 
         //Synthesis
         add(Gui_Synthesis, "Item Workshop");
+        add(Gui_Synthesis_Exp, "Exp");
         add(Gui_Synthesis_Synthesise, "Synthesise Items");
         add(Gui_Synthesis_Synthesise_Title, "Synthesis");
         add(Gui_Synthesis_Synthesise_Create, "Create");

--- a/src/main/java/online/kingdomkeys/kingdomkeys/lib/Strings.java
+++ b/src/main/java/online/kingdomkeys/kingdomkeys/lib/Strings.java
@@ -482,17 +482,18 @@ public class Strings {
 
             // Synthesis
             Gui_Synthesis = "gui.synthesis",
+			Gui_Synthesis_Exp = Gui_Synthesis + ".exp",
             Gui_Synthesis_Main = Gui_Synthesis + ".main",
             Gui_Synthesis_Main_Title = Gui_Synthesis_Main + ".title",
             Gui_Synthesis_Main_Recipes = Gui_Synthesis_Main + ".recipes",
             Gui_Synthesis_Main_FreeDev = Gui_Synthesis_Main + ".freedevelopment",
             
             Gui_Synthesis_Synthesise = Gui_Synthesis + ".synthesise",
-	    Gui_Synthesis_Synthesise_Title = Gui_Synthesis_Synthesise + ".title",
+	    	Gui_Synthesis_Synthesise_Title = Gui_Synthesis_Synthesise + ".title",
             Gui_Synthesis_Synthesise_Create = Gui_Synthesis_Synthesise + ".create",
             
             Gui_Synthesis_Forge = Gui_Synthesis + ".forge",
-	    Gui_Synthesis_Forge_Title = Gui_Synthesis_Forge + ".title",
+	    	Gui_Synthesis_Forge_Title = Gui_Synthesis_Forge + ".title",
             Gui_Synthesis_Forge_Upgrade = Gui_Synthesis_Forge + ".upgrade",
             
             Gui_Synthesis_Materials = Gui_Synthesis + ".materials",

--- a/src/main/resources/assets/kingdomkeys/lang/de_de.json
+++ b/src/main/resources/assets/kingdomkeys/lang/de_de.json
@@ -617,6 +617,7 @@
   "gui.summonarmor.notenoughspace": "Du hast nicht ausreichend Platz in deinem Inventar",
 
   "gui.synthesis": "Mogry-Werkstatt",
+  "gui.synthesis.exp": "Erf",
   "gui.synthesis.forge": "Mogry-Schmiede",
   "gui.synthesis.forge.title": "Schmiede",
   "gui.synthesis.forge.upgrade": "Verstärken",
@@ -625,6 +626,7 @@
   "gui.synthesis.materials.take": "Entnehmen",
   "gui.synthesis.moogle.title": "%ss Mogry-Laden",
   "gui.synthesis.synthesise": "Item-Synthese",
+  "gui.synthesis.synthesise.title": "Synthese",
   "gui.synthesis.synthesise.create": "Erschaffen",
 
   "gui.synthesisbag.munny": "Taler",

--- a/src/main/resources/assets/kingdomkeys/lang/de_de.json
+++ b/src/main/resources/assets/kingdomkeys/lang/de_de.json
@@ -139,6 +139,13 @@
   "ability.ability_negative_combo.desc": "Die maximale Combo-Anzahl am Boden und in der Luft verringert sich um 1.\nMehrfaches Anlegen erhöht den Effekt.",
   "ability.ability_negative_combo.name": "Combo -",
 
+  "ability.ability_protect.desc":"Negiert 10% Schaden aus jeglichen Quellen.",
+  "ability.ability_protect.name":"Protes",
+  "ability.ability_protectra.desc":"Negiert 20% Schaden aus jeglichen Quellen.",
+  "ability.ability_protectra.name":"Protera",
+  "ability.ability_protectga.desc":"Negiert 40% Schaden aus jeglichen Quellen.",
+  "ability.ability_protectga.name":"Protega",
+
   "ability.ability_scan.desc": "Inspiziert den aktuellen HP-Stand des Ziels.",
   "ability.ability_scan.name": "Analyse",
   "ability.ability_second_chance.desc": "Man behält 1 HP, auch wenn einem fataler Schaden zugefügt wurde.",


### PR DESCRIPTION
- Updated german translation
- adds in an oversight of one "page" being not translatable
- made the synth Tier + exp line a bit cleaner and the exp transalatable (it's just 3 letters but who knows)